### PR TITLE
Force static runtime libraries for all configurations of msvc builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,21 @@ project(${PROJECT_NAME})
 
 set(CMAKE_CXX_FLAGS "-g -Wall")
 
+# force static runtime libraries for msvc builds
+if(MSVC)
+  set(variables 
+    CMAKE_CXX_FLAGS_DEBUG
+    CMAKE_CXX_FLAGS_RELEASE
+	CMAKE_CXX_FLAGS_RELWITHDEBINFO
+	CMAKE_CXX_FLAGS_MINSIZEREL
+  )
+  foreach(variable ${variables})
+	if(${variable} MATCHES "/MD")
+	  string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+	endif()
+  endforeach()
+endif()
+
 # If you want your own include/ directory, set this, and then you can do
 # include_directories(${COMMON_INCLUDES}) in other CMakeLists.txt files.
 # set(COMMON_INCLUDES ${PROJECT_SOURCE_DIR}/include)


### PR DESCRIPTION
Hej thanks for providing this little example, I can perfectly use it for one of my own projects! While doing so, I experienced a link issue with the Microsoft compiler: gtest typically links against static runtime libraries, while the MSVC uses the dynamic libs by default. This patch fixes the issue straightforwardly by forcing static runtime libraries for MSVC builds. There may be more sophisticated solutions, but I guess for the example this is fine.

Cheers,
Stefan
